### PR TITLE
Add a jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,50 @@
+{
+  "globals"     : { "Phaser": false, "PIXI": false, "p2": false, "CocoonJS": false, "process": false, "game": true },
+
+  // Ignore Environment Globals
+  "browser"     : true,   // Standard browser globals e.g. `window`, `document`.
+
+  // Development
+  "devel"       : true,   // Allow developments statements e.g. `console.log();`.
+
+  // ECMAScript Support
+  "es3"         : true,   // Support legacy browser and javascript environments.
+  "esnext"      : false,  // This option tells JSHint that your code uses ECMAScript 6 specific syntax.
+  "strict"      : false,  // Require `use strict` pragma in every file.
+  "globalstrict": false,  // Allow global "use strict" (also enables 'strict').
+
+  // Functionality
+  "bitwise"     : false,  // Prohibit bitwise operators (&, |, ^, etc.).
+  "boss"        : true,   // Tolerate assignments inside if, for & while. Usually conditions & loops are for comparison, not assignments.
+  "camelcase"   : true,   // Force all variable names to use either camelCase style or UPPER_CASE with underscores.
+  "curly"       : true,   // Require {} for every new block or scope.
+  "eqeqeq"      : false,  // Require triple equals i.e. `===`.
+  "eqnull"      : true,   // Tolerate use of `== null`.
+  "evil"        : false,  // Tolerate use of `eval`.
+  "expr"        : false,  // Tolerate `ExpressionStatement` as Programs.
+  "forin"       : false,  // Tolerate `for in` loops without `hasOwnPrototype`.
+  "freeze"      : true,   // Prohibits overwriting prototypes of native objects such as Array and Date.
+  "funcscope"   : true,   // This option suppresses warnings about declaring variables inside of control structures while accessing them later from the outside.
+  "immed"       : true,   // Require immediate invocations to be wrapped in parens e.g. `( function(){}() );`
+  "latedef"     : true,   // Prohibit variable use before definition.
+  "laxbreak"    : false,  // Tolerate unsafe line breaks e.g. `return [\n] x` without semicolons.
+  "laxcomma"    : false,  // This option suppresses warnings about comma-first coding style.
+  "loopfunc"    : true,   // Allow functions to be defined within loops.
+  "noarg"       : true,   // Prohibit use of `arguments.caller` and `arguments.callee`.
+  "notypeof"    : false,  // This option suppresses warnings about invalid typeof operator values.
+  "shadow"      : true,   // Allows re-define variables later in code e.g. `var x=1; x=2;`.
+  "smarttabs"   : false,  // This option suppresses warnings about mixed tabs and spaces when the latter are used for alignmnent only.
+  "supernew"    : false,  // Tolerate `new function () { ... };` and `new Object;`.
+  "undef"       : true,   // Require all non-global variables be declared before they are used.
+  "unused"      : true,   // This option warns when you define and never use your variables.
+
+  // Styling
+  "indent"      : 2,      // Specify indentation spacing
+  "newcap"      : true,   // Require capitalization of all constructor functions e.g. `new F()`.
+  "noempty"     : true,   // Prohibit use of empty blocks.
+  "nonew"       : true,   // Prohibit use of constructors for side-effects.
+  "plusplus"    : false,  // Prohibit use of `++` & `--`.
+  "quotmark"    : false,  // This option enforces the consistency of quotation marks used throughout your code.
+  "sub"         : true,   // Tolerate all forms of subscript notation besides dot notation e.g. `dict['key']` instead of `dict.key`.
+  "trailing"    : true    // Prohibit trailing whitespaces.
+}

--- a/src/WorldGenerator.js
+++ b/src/WorldGenerator.js
@@ -1,14 +1,12 @@
-/* globals window */
-
 var WorldGenerator = function () {
     this.isFinished = false;
 };
 
 WorldGenerator.prototype = {
     generateWorld: function(){
-        window.console.log("generator started!");
+        console.log("generator started!");
         // Put generation code in here
-        window.console.log("generator finished!");
+        console.log("generator finished!");
         this.isFinished = true;
     }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,8 @@
-// Globals
-window.game = new Phaser.Game(1000, 600, Phaser.Auto, '');
+/* globals Menu, Cutscene, LevelOne */
+
+var game = new Phaser.Game(1000, 600, Phaser.Auto, '');
 
 var Main = function() {};
-var worldData;
-// startGame();
-
 
 Main.prototype = {
 

--- a/src/states/Cutscene.js
+++ b/src/states/Cutscene.js
@@ -1,4 +1,4 @@
-/* globals window WorldGenerator*/
+/* globals WorldGenerator */
 
 var Cutscene = function () {
   this.generator = null;
@@ -9,23 +9,23 @@ Cutscene.prototype = {
 
   beginCutscene: function() {
     // All the code in this function replace with actual cutscene
-    var background_bmd = window.game.add.bitmapData(window.game.width, window.game.height);
-    var grd = background_bmd.context.createLinearGradient(0, 0, window.game.width, window.game.height);
+    var backgroundBmd = game.add.bitmapData(game.width, game.height);
+    var grd = backgroundBmd.context.createLinearGradient(0, 0, game.width, game.height);
     grd.addColorStop(0, "rgb(200, 50, 50)");
     grd.addColorStop(0.3, "rgb(200, 0, 75)");
     grd.addColorStop(1, "rgb(200, 0, 150)");
-    background_bmd.context.fillStyle = grd;
-    background_bmd.context.fillRect(0, 0, window.game.width, window.game.height); 
-    window.game.add.sprite(0, 0, background_bmd);
+    backgroundBmd.context.fillStyle = grd;
+    backgroundBmd.context.fillRect(0, 0, game.width, game.height); 
+    game.add.sprite(0, 0, backgroundBmd);
     
-    var loader = window.game.add.sprite(10, 10, 'loadingImage');
+    var loader = game.add.sprite(10, 10, 'loadingImage');
     this.cutscene = loader.animations.add('load', [0, 1, 2], 1, false); 
     this.cutscene.play('load');
   },
 
   preload: function() {
-    window.game.load.script('WorldGenerator', 'src/WorldGenerator.js'); 
-    window.game.load.spritesheet('loadingImage', '../../assets/loadingImage.png', 270, 90, 3);
+    game.load.script('WorldGenerator', 'src/WorldGenerator.js'); 
+    game.load.spritesheet('loadingImage', '../../assets/loadingImage.png', 270, 90, 3);
   },
 
   create: function() {
@@ -36,7 +36,7 @@ Cutscene.prototype = {
 
   update: function() {
     if(this.cutscene.isFinished && this.generator.isFinished){
-      window.game.state.start('LevelOne');
+      game.state.start('LevelOne');
     }
   },
 

--- a/src/states/Menu.js
+++ b/src/states/Menu.js
@@ -1,5 +1,3 @@
-/* globals window */
-
 //In later changes I may want to create a list of buttons rather than store each individually
 //It may be nice to have something more dynamic
 var Menu = function () {
@@ -13,26 +11,25 @@ var Menu = function () {
   this.seedButton = null;
   this.returnButton = null;
   this.menuState = 'MAIN';
-
 };
 
 Menu.prototype = {
   preload: function() {
-    window.game.load.script('sunset', 'assets/shaders/MenuShader.js');
+    game.load.script('sunset', 'assets/shaders/MenuShader.js');
   },
 
   create: function() {
-    window.game.stage.backgroundColor = '#FFFFFF';
-    window.game.scale.fullScreenScaleMode = Phaser.ScaleManager.NO_SCALE;
+    game.stage.backgroundColor = '#FFFFFF';
+    game.scale.fullScreenScaleMode = Phaser.ScaleManager.NO_SCALE;
     /*Apply filter to image in background*/
-    this.backDrop = window.game.add.image();
-    this.backDrop.width = window.game.width;
-    this.backDrop.height = window.game.height;
-    this.backDropFilter = window.game.add.filter('sunset', window.game.width, window.game.height);
+    this.backDrop = game.add.image();
+    this.backDrop.width = game.width;
+    this.backDrop.height = game.height;
+    this.backDropFilter = game.add.filter('sunset', game.width, game.height);
     this.backDrop.filters = [this.backDropFilter];
     
     //draw title text
-    this.titleText = window.game.add.text((window.game.width * 0.5 - 64) * 0.5, (window.game.height * 0.5 - 70) * 0.61, 'POTENTIAL FORTNIGHT');
+    this.titleText = game.add.text((game.width * 0.5 - 64) * 0.5, (game.height * 0.5 - 70) * 0.61, 'POTENTIAL FORTNIGHT');
     this.titleText.anchor.setTo(0.5, 0.5);
     this.titleText.fontSize = 30;
     this.titleText.fill = 'white';
@@ -42,7 +39,7 @@ Menu.prototype = {
   },
 
   update: function() {
-    this.backDropFilter.update(window.game.input.activePointer);
+    this.backDropFilter.update(game.input.activePointer);
   },
 
   render: function() {
@@ -51,26 +48,26 @@ Menu.prototype = {
 
   drawMain: function() {
     //make buttons and initialize their functions
-    this.startButton = this.makeButton(window.game.world.centerX, window.game.world.centerY - 20, 'START');
-    this.startButton.events.onInputDown.add(function() {window.game.state.start('Cutscene');});
-    this.optionButton = this.makeButton(window.game.world.centerX, window.game.world.centerY + 20, 'OPTIONS');
+    this.startButton = this.makeButton(game.world.centerX, game.world.centerY - 20, 'START');
+    this.startButton.events.onInputDown.add(function() {game.state.start('Cutscene');});
+    this.optionButton = this.makeButton(game.world.centerX, game.world.centerY + 20, 'OPTIONS');
     this.optionButton.events.onInputDown.add(this.optionMenuToggle, this);
-    this.fullscreenButton = this.makeButton(window.game.world.centerX, window.game.world.centerY - 60, 'FULLSCREEN');
+    this.fullscreenButton = this.makeButton(game.world.centerX, game.world.centerY - 60, 'FULLSCREEN');
     this.fullscreenButton.visible = false;
     this.fullscreenButton.events.onInputDown.add(this.fullscreenToggle, this);
-    this.muteButton = this.makeButton(window.game.world.centerX, window.game.world.centerY - 20, 'SOUND: ' + (window.game.sound.mute ? 'OFF':'ON'));
+    this.muteButton = this.makeButton(game.world.centerX, game.world.centerY - 20, 'SOUND: ' + (game.sound.mute ? 'OFF':'ON'));
     this.muteButton.visible = false;
-    this.muteButton.events.onInputDown.add(function(target) {window.game.sound.mute = window.game.sound.mute === false; target.setText('SOUND: '+ (window.game.sound.mute ? 'OFF':'ON'));});
-    this.seedButton = this.makeButton(window.game.world.centerX, window.game.world.centerY + 20, 'SEED: ');
+    this.muteButton.events.onInputDown.add(function(target) {game.sound.mute = game.sound.mute === false; target.setText('SOUND: '+ (game.sound.mute ? 'OFF':'ON'));});
+    this.seedButton = this.makeButton(game.world.centerX, game.world.centerY + 20, 'SEED: ');
     this.seedButton.visible = false;
-    this.returnButton = this.makeButton(window.game.world.centerX, window.game.world.centerY + 60, 'RETURN');
+    this.returnButton = this.makeButton(game.world.centerX, game.world.centerY + 60, 'RETURN');
     this.returnButton.visible = false;
     this.returnButton.events.onInputDown.add(this.optionMenuToggle, this);
   },
 
   //generic button creator, initializes buttons with standard formatting
   makeButton: function(x, y, name) {
-    var button = window.game.add.text(x, y, name);
+    var button = game.add.text(x, y, name);
     button.anchor.setTo(0.5, 0.5);
     button.fontSize = 25;
     button.fill = 'white';
@@ -82,12 +79,12 @@ Menu.prototype = {
 
   //functonality for the fullscreen button
   fullscreenToggle: function() {
-    if (window.game.scale.isFullScreen) {
+    if (game.scale.isFullScreen) {
       this.resizeGame(1000, 600);
-      window.game.scale.stopFullScreen();
+      game.scale.stopFullScreen();
     } else {
-      this.resizeGame(window.screen.width, window.screen.height);
-      window.game.scale.startFullScreen();   
+      this.resizeGame(screen.width, screen.height);
+      game.scale.startFullScreen();   
     }
   },
 
@@ -115,16 +112,16 @@ Menu.prototype = {
 
   // called in order to resize the game window, used with fullscreen
   resizeGame: function(w, h) {
-    window.game.scale.setGameSize(w, h);
-    this.backDropFilter.setResolution(window.game.width, window.game.height);
-    this.backDrop.width = window.game.width;
-    this.backDrop.height = window.game.height;
-    this.titleText.position.setTo((window.game.width * 0.5 - 64) * 0.5, (window.game.height * 0.5 - 70) * 0.61);
-    this.startButton.position.setTo(window.game.world.centerX, window.game.world.centerY - 20);
-    this.optionButton.position.setTo(window.game.world.centerX, window.game.world.centerY + 20);
-    this.fullscreenButton.position.setTo(window.game.world.centerX, window.game.world.centerY - 60);
-    this.muteButton.position.setTo(window.game.world.centerX, window.game.world.centerY - 20);
-    this.seedButton.position.setTo(window.game.world.centerX, window.game.world.centerY + 20);
-    this.returnButton.position.setTo(window.game.world.centerX, window.game.world.centerY + 60);
+    game.scale.setGameSize(w, h);
+    this.backDropFilter.setResolution(game.width, game.height);
+    this.backDrop.width = game.width;
+    this.backDrop.height = game.height;
+    this.titleText.position.setTo((game.width * 0.5 - 64) * 0.5, (game.height * 0.5 - 70) * 0.61);
+    this.startButton.position.setTo(game.world.centerX, game.world.centerY - 20);
+    this.optionButton.position.setTo(game.world.centerX, game.world.centerY + 20);
+    this.fullscreenButton.position.setTo(game.world.centerX, game.world.centerY - 60);
+    this.muteButton.position.setTo(game.world.centerX, game.world.centerY - 20);
+    this.seedButton.position.setTo(game.world.centerX, game.world.centerY + 20);
+    this.returnButton.position.setTo(game.world.centerX, game.world.centerY + 60);
   }
 };


### PR DESCRIPTION
I also changed all references to `window.game` to just `game` I don't like the verbosity of calling `window.game` everytime we need to access the game object given that using `game` alone is essentially the same.

As an alternative it looks like state constructors can accept a game parameter, this way we could access game using `this.game` which I think is preferable to `window.game`.

The jshintrc file I included below is taken almost directly from the phaser github, I think I edited it to fit with our style but please take a close look at the options before giving this the go ahead.
