### PR TITLE
made resource names a globally accessable variable

### DIFF
--- a/src/BaseObject.js
+++ b/src/BaseObject.js
@@ -1,4 +1,4 @@
-/* globals TextGroup*/
+/* globals TextGroup, resourceNames*/
 var BaseObject = function(resources) {
   //whether or not a base is active
   //needs to be like this so we can use a getter and setter

--- a/src/BaseObject.js
+++ b/src/BaseObject.js
@@ -3,29 +3,18 @@ var BaseObject = function(resources) {
   //whether or not a base is active
   //needs to be like this so we can use a getter and setter
   this._active = false;
+
   //reference to the resource composition of the sector
   //can be used to lower resource abundance in sector data
   //but currently just used to read abundance of each material
   this.resources = resources;
 
-  //for now list all the possible resources
-  //must correspond with those defined in archetype.js
-  //later we may want a more robust approach
-  this.metalCount = 0;
-  this.rockCount = 0;
-  this.liquidCount = 0;
-  this.woodCount = 0;
-  this.plantCount = 0;
-  this.gasCount = 0;
+  //resources to be counted
+  this.resourceCount = [0, 0, 0, 0, 0, 0];
 
   //gatherers represent arbitrary units which gather resources
   //we can make them automiton or people for gameplay sake
-  this.metalGatherers = 1;
-  this.rockGatherers = 1;
-  this.liquidGatherers = 1;
-  this.woodGatherers = 1;
-  this.plantGatherers = 1;
-  this.gasGatherers = 1;
+  this.gatherers = [1, 1, 1, 1, 1, 1];
 
   //used to offset the rate of resource gathering
   //but at some point this should be tied into time rather than arbitrary units
@@ -69,12 +58,9 @@ BaseObject.prototype = {
   //    accept a delta time in the function 
   //      in order to do this we need to first keep track of time globally
   update: function() {
-    this.metalCount += this.globalRate * this.metalGatherers * this.resources.metal.abundance;
-    this.rockCount += this.globalRate * this.rockGatherers * this.resources.rock.abundance;
-    this.liquidCount += this.globalRate * this.liquidGatherers * this.resources.liquid.abundance;
-    this.woodCount += this.globalRate * this.woodGatherers * this.resources.wood.abundance;
-    this.plantCount += this.globalRate * this.plantGatherers * this.resources.plant.abundance;
-    this.gasCount += this.globalRate * this.gasGatherers * this.resources.gas.abundance;
+    for (var i = 0; i < this.resourceCount.length; i++) {
+      this.resourceCount[i] += this.globalRate * this.gatherers[i] * this.resources.type[i].abundance;
+    }
   },
 
   //use getters and setters so that the textgroup is initialized when the base is created
@@ -107,39 +93,31 @@ BaseObject.prototype = {
     //the use of context here may seem a tad hacky but it is the only way for the information to
     //be both easily updated and manually retreived
     var context = ctx || this;
-    return 'Resources:' +
-           '\nMetal: ' + Math.floor(context.metalCount) + 
-           '\nRock: ' + Math.floor(context.rockCount) +
-           '\nLiquid: ' + Math.floor(context.liquidCount) +
-           '\nWood: ' + Math.floor(context.woodCount) +
-           '\nPlant: ' + Math.floor(context.plantCount) +
-           '\nGas: ' + Math.floor(context.gasCount);
+    var txt = "Resources:";
+    for (var i = 0; i < context.resourceCount.length; i++) {
+      txt += "\n" + resourceNames[i] + ": " + Math.floor(context.resourceCount[i]);
+    }
+    return txt;
   },
 
   getGatherers: function(ctx) {
     //returns a formatted string of how many workers there are in each resource
     var context = ctx || this;
-    return 'Workers:' +
-           '\nMetal: ' + Math.floor(context.metalGatherers) + 
-           '\nRock: ' + Math.floor(context.rockGatherers) +
-           '\nLiquid: ' + Math.floor(context.liquidGatherers) +
-           '\nWood: ' + Math.floor(context.woodGatherers) +
-           '\nPlant: ' + Math.floor(context.plantGatherers) +
-           '\nGas: ' + Math.floor(context.gasGatherers);
-
+    var txt = "Workers:";
+    for (var i = 0; i < context.gatherers.length; i++) {
+      txt += "\n" + resourceNames[i] + ": " + Math.floor(context.gatherers[i]);
+    }
+    return txt;
   }, 
 
   getAbundance: function(ctx) {
     //return a formatted string with the abundance of each resource in this sector
     var context = ctx || this;
-    return 'Abundance:' +
-           '\nMetal: ' + context.resources.metal.abundance.toPrecision(3) + 
-           '\nRock: ' + context.resources.rock.abundance.toPrecision(3) +
-           '\nLiquid: ' + context.resources.liquid.abundance.toPrecision(3) +
-           '\nWood: ' + context.resources.wood.abundance.toPrecision(3) +
-           '\nPlant: ' + context.resources.plant.abundance.toPrecision(3) +
-           '\nGas: ' + context.resources.gas.abundance.toPrecision(3);
-
+    var txt = "Abundance:";
+    for (var i = 0; i < context.resources.type.length; i++) {
+      txt += "\n" + resourceNames[i] + ": " + context.resources.type[i].abundance.toPrecision(3);
+    }
+    return txt;
   }
 
 };

--- a/src/PlanetData.js
+++ b/src/PlanetData.js
@@ -1,4 +1,4 @@
-/* globals SectorData, utils, noise, Resources, resourceNames, rcrs */
+/* globals SectorData, utils, noise, Resources, rcrs */
 
 var PlanetData = function () {
   this.sectors = [];

--- a/src/PlanetData.js
+++ b/src/PlanetData.js
@@ -12,6 +12,7 @@ var PlanetData = function () {
   this.waterHue = null;
 
   this.resourcetypes = new Resources();
+  this.resourcetypes.generate();
   //this.resourcetypes.print();
 
   //when we generate higher level planet data we will use that to replace all the math.random() calls
@@ -187,13 +188,13 @@ PlanetData.prototype = {
         // based on the type of area assign properties
         // TODO make abundance decisions better
         if (type == 'Humid') {
-          resources.liquid.abundance = 1.0;
+          resources.type[rcrs.Liquid].abundance = 1.0;
         } else if (type == 'Fertile') {
-          resources.plant.abundance = 1.0;
+          resources.type[rcrs.Plant].abundance = 1.0;
         } else if (type == 'Rocky') {
-          resources.rock.abundance = 1.0;
+          resources.type[rcrs.Rock].abundance = 1.0;
         } else if (type == 'Mountainous') {
-          resources.metal.abundance = 1.0;
+          resources.type[rcrs.Metal].abundance = 1.0;
         } else {
           type = 'Fertile';
           console.log('invalid type passed into sector at: x: ' + x + ' y: '+ y);

--- a/src/PlanetData.js
+++ b/src/PlanetData.js
@@ -1,4 +1,4 @@
-/* globals SectorData, utils, noise, Resources */
+/* globals SectorData, utils, noise, Resources, resourceNames, rcrs */
 
 var PlanetData = function () {
   this.sectors = [];

--- a/src/archetype.js
+++ b/src/archetype.js
@@ -46,6 +46,12 @@ var Material = function(mat) {
     this.abundance = mat.abundance;
   }
   
+  //this is here so we can verify that we are tracking correct resources when we access them
+  if (mat.name == null) {
+    this.name = "unnamed";
+  } else {
+    this.name = mat.name;
+  }
 };
 
 Material.prototype = {
@@ -66,13 +72,13 @@ Material.prototype = {
     //and that high potential energy is good
     //makes higher quality materials less abundant
     var ab = 1.0 - ((hd+(1.0 - ad)+pd)/3.0);
-    return new Material({hardness:h, activation:a, potential:p, abundance:ab});
+    return new Material({hardness:h, activation:a, potential:p, abundance:ab, name:this.name});
   }, 
 
   //prints out material information to the console
   //X should be the type of material that it is
-  print: function(x) {
-   console.log(x + ":" +
+  print: function() {
+   console.log(this.name + ":" +
               "\nhardness: " + this.hardness.toPrecision(3) +
               "\nactivation energy: " + this.activation.toPrecision(3) +
               "\npotential energy: " + this.potential.toPrecision(3) +
@@ -81,7 +87,7 @@ Material.prototype = {
 
   //returns new material with the same properties as the current one
   clone: function() {
-    return new Material({hardness:this.hardness, activation:this.activation, potential:this.potential, distribution:this.distribution, abundance:this.abundance});
+    return new Material({hardness:this.hardness, activation:this.activation, potential:this.potential, distribution:this.distribution, abundance:this.abundance, name:this.name});
   }
 };
 
@@ -89,46 +95,43 @@ Material.prototype = {
 //these will denote the values that do not change between planets
 //consider this a type of struct or definition
 var Archetypes = function() {
-  this.metal = new Material({activation:{max:70, min:30}, potential:{max:100, min:50}, hardness:{max:90, min:40}, distribution: 1});
-  this.rock = new Material({activation:{max:100, min:50}, potential:{max:80, min:30}, hardness:{max:100, min:70}, distribution: 1});
-  this.liquid = new Material({activation:{max:80, min:0}, potential:{max:70, min:40}, hardness:{max:10, min:0}, distribution: 1});//maybe curve towards high number
-  this.wood = new Material({activation:{max:30, min:0}, potential:{max:40, min:30}, hardness:{max:50, min:30}, distribution: 1});
-  this.plant = new Material({activation:{max:20, min:0}, potential:{max:30, min:20}, hardness:{max:30, min:10}, distribution: 1});
-  this.gas = new Material({activation:{max:50, min:0}, potential:{max:50, min:10}, hardness:{max:5, min:0}, distribution: 1});
+  this.type = [];
+  
+  this.type.push(new Material({activation:{max:70, min:30}, potential:{max:100, min:50}, hardness:{max:90, min:40}, distribution: 1, name: "Metal"}));
+  this.type.push(new Material({activation:{max:100, min:50}, potential:{max:80, min:30}, hardness:{max:100, min:70}, distribution: 1, name: "Rock"}));
+  this.type.push(new Material({activation:{max:80, min:0}, potential:{max:70, min:40}, hardness:{max:10, min:0}, distribution: 1, name: "Liquid"}));//maybe curve towards high number
+  this.type.push(new Material({activation:{max:30, min:0}, potential:{max:40, min:30}, hardness:{max:50, min:30}, distribution: 1, name: "Wood"}));
+  this.type.push(new Material({activation:{max:20, min:0}, potential:{max:30, min:20}, hardness:{max:30, min:10}, distribution: 1, name: "Plant"}));
+  this.type.push(new Material({activation:{max:50, min:0}, potential:{max:50, min:10}, hardness:{max:5, min:0}, distribution: 1, name: "Gas"}));
 };
 
 //this gives a specific planet unique properties based on our Archetypal materials
 //this should be the only function called from other files
 var Resources = function() {
-  var archetypes = new Archetypes();
-  this.metal = archetypes.metal.generateInstance();
-  this.rock = archetypes.rock.generateInstance();
-  this.liquid = archetypes.liquid.generateInstance();
-  this.wood = archetypes.wood.generateInstance();
-  this.plant = archetypes.plant.generateInstance();
-  this.gas = archetypes.gas.generateInstance();
-
+  this.type = [];
 };
 
 Resources.prototype = {
+  //this initializes the Resource types with values
+  generate: function() {
+    var archetypes = new Archetypes(); 
+    for (var i = 0; i < archetypes.type.length; i++) {
+      this.type.push(archetypes.type[i].generateInstance());
+    }
+  },
+
   print: function() {
-    this.metal.print('metal');
-    this.rock.print('rock');
-    this.liquid.print('liquid');
-    this.wood.print('wood');
-    this.plant.print('plant');
-    this.gas.print('gas');
+    for (var i = 0; i < this.type.length; i++) {
+      this.type[i].print();
+    }
   },
 
   //clone the object so we dont have to pass by reference
   clone: function() {
     var r = new Resources();
-    r.metal = this.metal.clone();
-    r.rock = this.rock.clone();
-    r.liquid = this.liquid.clone();
-    r.wood = this.wood.clone();
-    r.plant = this.plant.clone();
-    r.gas = this.gas.clone();
+    for (var i = 0; i < this.type.length; i++) {
+      r.type.push(this.type[i].clone());
+    }
     return r;
   }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -2,8 +2,8 @@
 
 var game = new Phaser.Game(1000, 600, Phaser.Auto, '');
 var planetData = null;
-var resourceNames = ["Metal", "Rock", "Liquid", "Wood", "Plant", "Gas"];
-var rcrs = {Metal:0, Rock:1, Liquid:2, Wood:3, Plant:4, Gas:5};
+var resourceNames = null; 
+var rcrs = null; 
 
 var Main = function() {};
 
@@ -22,6 +22,8 @@ Main.prototype = {
     game.state.add('Menu', Menu); 
     game.state.add('LevelOne', LevelOne);
     planetData = new PlanetData();
+    resourceNames = ["Metal", "Rock", "Liquid", "Wood", "Plant", "Gas"];
+    rcrs = {Metal:0, Rock:1, Liquid:2, Wood:3, Plant:4, Gas:5};
     // TODO : Add a splash screen
     game.state.start('Menu');
   }

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,8 @@
 
 var game = new Phaser.Game(1000, 600, Phaser.Auto, '');
 var planetData = null;
+var resourceNames = ["Metal", "Rock", "Liquid", "Wood", "Plant", "Gas"];
+var rcrs = {Metal:0, Rock:1, Liquid:2, Wood:3, Plant:4, Gas:5};
 
 var Main = function() {};
 


### PR DESCRIPTION
Responding to Issue #62 I have removed the card coding of the resource names. Now all resource containers can be looped over and uniquely identified by the global `resourceNames` or `rcrs`. This will allow us to be more flexible when working with resources and allow us to potentially pave the way for resources with procedural names or outright procedural resources.