### PR TITLE
Added Player node and basic resource tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ Thumbs.db
 
 # Godot import directory #
 ##########################
-.import
+*.import

--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,7 @@ driver="ALSA"
 global="*res://src/global.gd"
 resources="*res://src/resources.gd"
 planet="*res://src/planet.gd"
+player="*res://src/player.gd"
 
 [display]
 

--- a/src/player.gd
+++ b/src/player.gd
@@ -1,0 +1,12 @@
+extends Node
+
+var resourceStock = {}
+var gatherers = {}
+var processors = {}
+var productionEfficiency = 2
+
+func _ready():
+	for key in resources.types:
+		resourceStock[key] = 0
+		gatherers[key] = 1
+		processors[key] = 1

--- a/src/scenes/BasePanel.tscn
+++ b/src/scenes/BasePanel.tscn
@@ -70,7 +70,7 @@ LineEdit/styles/focus = null
 LineEdit/styles/normal = null
 LineEdit/styles/read_only = null
 
-[node name="Base" type="Control"]
+[node name="Base" type="Control" index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -141,16 +141,127 @@ _sections_unfolded = [ "Anchor", "Margin" ]
 visible = false
 z_index = -1
 
-[node name="GatherButtons" type="GridContainer" parent="." index="3"]
+[node name="ProductionButton" type="Button" parent="." index="3"]
 
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 100.0
+margin_top = 50.0
+margin_right = -800.0
+margin_bottom = -550.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+focus_mode = 2
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+toggle_mode = false
+enabled_focus_mode = 2
+shortcut = null
+group = null
+text = "Production"
+flat = false
+align = 1
+
+[node name="BuildingButton" type="Button" parent="." index="4"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 300.0
+margin_top = 50.0
+margin_right = -800.0
+margin_bottom = -550.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+focus_mode = 2
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+toggle_mode = false
+enabled_focus_mode = 2
+shortcut = null
+group = null
+text = "Building"
+flat = false
+align = 1
+_sections_unfolded = [ "Margin" ]
+
+[node name="ResourceStock" type="GridContainer" parent="." index="5"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 700.0
+margin_top = 100.0
+margin_right = -100.0
+margin_bottom = -640.0
+rect_min_size = Vector2( 100, 150 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+columns = 1
+_sections_unfolded = [ "Anchor", "Margin", "Rect" ]
+
+[node name="PropertyDisplay" type="GridContainer" parent="." index="6"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 700.0
+margin_top = 360.0
+margin_right = -100.0
+margin_bottom = -100.0
+rect_min_size = Vector2( 100, 150 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+columns = 1
+_sections_unfolded = [ "Anchor", "Margin", "Rect" ]
+
+[node name="Production" type="GridContainer" parent="." index="7"]
+
+editor/display_folded = true
 anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 100.0
 margin_top = 100.0
-margin_right = -640.0
-margin_bottom = -349.0
+margin_right = -400.0
+margin_bottom = -100.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+focus_mode = 2
+mouse_filter = 0
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+columns = 1
+_sections_unfolded = [ "Focus", "Margin", "Mouse", "Rect" ]
+
+[node name="GatherButtons" type="GridContainer" parent="Production" index="0"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 200.0
+margin_bottom = 150.0
+rect_min_size = Vector2( 200, 150 )
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 1
@@ -158,31 +269,56 @@ mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
 columns = 1
-_sections_unfolded = [ "Margin" ]
+_sections_unfolded = [ "Anchor", "Margin", "Rect" ]
 
-[node name="ProcessButtons" type="GridContainer" parent="." index="4"]
+[node name="ProcessButtons" type="GridContainer" parent="Production" index="1"]
 
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 154.0
+margin_right = 200.0
+margin_bottom = 304.0
+rect_min_size = Vector2( 200, 150 )
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+columns = 1
+_sections_unfolded = [ "Anchor", "Margin", "Rect" ]
+
+[node name="Building" type="GridContainer" parent="." index="8"]
+
+visible = false
 anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 100.0
-margin_top = 350.0
-margin_right = -640.0
+margin_top = 100.0
+margin_right = -400.0
 margin_bottom = -100.0
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
-mouse_filter = 1
+focus_mode = 2
+mouse_filter = 0
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 1
 size_flags_vertical = 1
 columns = 1
-_sections_unfolded = [ "Margin" ]
+_sections_unfolded = [ "Anchor", "Focus", "Margin", "Mouse", "Rect" ]
 
 [connection signal="pressed" from="Button" to="." method="_on_Button_pressed"]
 
 [connection signal="pressed" from="Scene" to="." method="_on_Scene_pressed"]
 
 [connection signal="pressed" from="Scene" to="SceneView" method="_on_Scene_pressed"]
+
+[connection signal="pressed" from="ProductionButton" to="." method="_on_ProductionButton_pressed"]
+
+[connection signal="pressed" from="BuildingButton" to="." method="_on_BuildingButton_pressed"]
 
 

--- a/src/scenes/Level.tscn
+++ b/src/scenes/Level.tscn
@@ -6,7 +6,7 @@
 [ext_resource path="res://src/scenes/BasePanel.tscn" type="PackedScene" id=4]
 [ext_resource path="res://src/scenes/Messenger.tscn" type="PackedScene" id=5]
 
-[node name="Level" type="Control"]
+[node name="Level" type="Control" index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0

--- a/src/scenes/Menu.tscn
+++ b/src/scenes/Menu.tscn
@@ -113,7 +113,7 @@ shader = SubResource( 4 )
 shader_param/mouse = null
 shader_param/resolution = null
 
-[node name="Root" type="Control"]
+[node name="Root" type="Control" index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0

--- a/src/scenes/TimerButton.tscn
+++ b/src/scenes/TimerButton.tscn
@@ -4,7 +4,7 @@
 [ext_resource path="res://src/scripts/TimerButton.gd" type="Script" id=2]
 [ext_resource path="res://assets/themes/defaultTheme.tres" type="Theme" id=3]
 
-[node name="TimerButton" type="ViewportContainer"]
+[node name="TimerButton" type="ViewportContainer" index="0"]
 
 material = ExtResource( 1 )
 anchor_left = 0.0
@@ -60,7 +60,7 @@ shadow_atlas_quad_0 = 2
 shadow_atlas_quad_1 = 2
 shadow_atlas_quad_2 = 3
 shadow_atlas_quad_3 = 4
-_sections_unfolded = [ "Render Target", "Rendering" ]
+_sections_unfolded = [ "GUI", "Render Target", "Rendering" ]
 
 [node name="Button" type="Button" parent="Viewport" index="0"]
 

--- a/src/scripts/BasePanel.gd
+++ b/src/scripts/BasePanel.gd
@@ -9,19 +9,31 @@ func _ready():
 	#TODO Time to gather should be based off properties
 	for key in resources.types:
 		var new_button = timer_button.instance()
+		new_button.name = key
 		new_button.text = "Gather " + key
 		new_button.time = 10.0
 		new_button.connect("finished", self, "resource_gather", [key])
-		$GatherButtons.add_child(new_button)
+		$Production/GatherButtons.add_child(new_button)
 	#Then buttons to process each material
 	#TODO time to process should be based off properties
 	for key in resources.types:
 		var new_button = timer_button.instance()
+		new_button.name = key
 		new_button.text = "Process " + key
 		new_button.time = 4.0
+		new_button.connect("started", self, "resource_process_start", [key])
 		new_button.connect("finished", self, "resource_process", [key])
-		$ProcessButtons.add_child(new_button)
+		$Production/ProcessButtons.add_child(new_button)
+	#Labels to display the stock of each resource
+	for key in player.resourceStock:
+		var new_label = Label.new()
+		new_label.name = key
+		new_label.text = key + ": " + str(player.resourceStock[key])
+		$ResourceStock.add_child(new_label)
 
+func update_resource(key):
+	$ResourceStock.get_node(key).text = key + ": " + str(player.resourceStock[key])
+	
 func _on_Button_pressed():
 	emit_signal("switch_scene")
 
@@ -33,7 +45,47 @@ func _on_Scene_pressed():
 		get_node("Scene").set_text("Hide Scene")
 
 func resource_gather(key):
-	print("gathered " + key)
+	#Gathers a single unit of resource
+	player.resourceStock[key] += player.gatherers[key]
+	update_resource(key)
+	
+func resource_process_start(key):
+	#remove require materials for processing
+	#Each processor uses 1 material and produces player.productionEfficiency amount
+	if player.resourceStock[key] >= player.processors[key]:
+		player.resourceStock[key] -= player.processors[key]
+		update_resource(key)
+	else:
+		$Production/ProcessButtons.get_node(key).tween.stop_all()
+		$Production/ProcessButtons.get_node(key).reset_loading_bar(false, null, false)
+	
 	
 func resource_process(key):
-	print("processed " + key)
+	#processing just using a material to increase the amount
+	#you already have
+	player.resourceStock[key] += player.productionEfficiency * player.processors[key]
+	update_resource(key)
+	
+func disable_buttons(node):
+	for child in node.get_children():
+		for c in child.get_children():
+			c.disable_button(true)
+			
+func enable_buttons(node):
+	for child in node.get_children():
+		for c in child.get_children():
+			c.disable_button(false)
+
+func _on_ProductionButton_pressed():
+	$Building.hide()
+	disable_buttons($Building)
+	$Production.show()
+	enable_buttons($Production)
+	
+
+func _on_BuildingButton_pressed():
+	$Building.show()
+	enable_buttons($Building)
+	$Production.hide()
+	disable_buttons($Production)
+

--- a/src/scripts/TimerButton.gd
+++ b/src/scripts/TimerButton.gd
@@ -4,6 +4,7 @@
 extends ViewportContainer
 
 signal finished
+signal started
 var tween
 #material needs to be loaded this way otherwise uniform values are shared between all buttons
 var timer_mat = preload("res://assets/shaders/TimerButtonMaterial.tres")
@@ -17,18 +18,22 @@ func update_loading_bar(progress):
 	material.set_shader_param("progress", progress)
 
 #resets loading bar and emits signal when finished
-func reset_loading_bar(object, method):
+func reset_loading_bar(object, method, fin):
 	material.set_shader_param("progress", 1.0)
 	active = false
-	emit_signal("finished")
+	if fin:
+		emit_signal("finished")
 	$Viewport/Button.pressed = false
 	$Viewport/Button.toggle_mode = false
+	
+func disable_button(value):
+	$Viewport.gui_disable_input = value
 
 func _ready():
 	material = timer_mat.duplicate(true)
 	##initialize tween
 	tween = $LoadTween
-	tween.connect("tween_completed", self, "reset_loading_bar")
+	tween.connect("tween_completed", self, "reset_loading_bar", [true])
 	#pass in width and position to replace UV
 	material.set_shader_param("width", rect_size.x)
 	material.set_shader_param("text", $Viewport.get_texture())
@@ -49,6 +54,7 @@ func _on_Button_pressed():
 		tween.interpolate_method(self, "update_loading_bar", 0.0, 1.0, time, Tween.TRANS_LINEAR, Tween.EASE_OUT)
 		tween.start()
 		active = true
+		emit_signal("started")
 		
 func _set_text(a):
 	text = a


### PR DESCRIPTION
Description says it all. Now we can keep track of resources in a global player node. I also added dictionaries for gatherers, processors, and production efficiency. 

I came up with a new way to handle processing of resources. Instead of managing a ton of different resource types and whatnot, we just consume resources and time to produce additional resources. Currently it takes a set amount of time it costs one resource per processor and then it outputs processor*efficiency resources. This way we can make gathering kind of an early game practice, and then once you have lots of resources you will build processors that will continue expanding your resources.

I also added in a GUI so we can separate menus in the base. Currently there is just a production menu and an empty building menu.